### PR TITLE
Fix for GH Issue 13

### DIFF
--- a/Tomboy/RecentChanges.cs
+++ b/Tomboy/RecentChanges.cs
@@ -729,6 +729,7 @@ namespace Tomboy
 		void OnNotesDeleted (object sender, Note deleted)
 		{
 			RestoreMatchesWindow ();
+			UpdateResults ();	// To Fix GH Issue 13, Davo, 2016/09/07
 		}
 
 		void OnNotesChanged (object sender, Note changed)


### PR DESCRIPTION
This is pretty simple really. And I expect authors intended it all along.
Problem is the SeachBox shows the list of notes available when it was last refreshed. If a note is deleted while that box is still open, it does not, at present, get refreshed, the user is offered a chance to open note that no longer exists. And bad things happen .....
There is already a function to respond to a note being deleted, all we do is call  refresh from there.

https://github.com/tomboy-notes/tomboy/issues/13

David 