### PR TITLE
build: migrate off of the long outdated gnome-common infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ Makefile.in
 /intltool-merge.in
 /intltool-extract
 /intltool-extract.in
-/gnome-doc-utils.make
 /INSTALL
 /libtool
 /ltmain.sh
@@ -64,6 +63,7 @@ Makefile.in
 /help/*/*.xml
 !/help/C/*.xml
 /help/*/*.mo
+/help/*/*.stamp
 
 # /po
 /po/*.gmo

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,6 @@ SUBDIRS = data libtomboy Tomboy test po help
 ACLOCAL_AMFLAGS = -I m4 ${ACLOCAL_FLAGS}
 
 EXTRA_DIST = 			\
-	gnome-doc-utils.make	\
 	\
 	intltool-extract.in     \
 	intltool-merge.in       \
@@ -18,17 +17,13 @@ EXTRA_DIST = 			\
 	MAINTAINERS
 
 DISTCLEANFILES = 			\
-	gnome-doc-utils.make		\
 	\
 	intltool-extract        	\
 	intltool-merge          	\
 	intltool-update         	\
 	po/.intltool-merge-cache
 
-DISTCHECK_CONFIGURE_FLAGS = --disable-schemas-install --disable-scrollkeeper --disable-update-mimedb
-
-# Ignore scrollkeeper issues for now.  @#*$& scrollkeeper (from Evince)
-distuninstallcheck_listfiles = find . -type f -print | grep -v scrollkeeper | grep -v /share/gnome/help/ | grep -v \.omf
+DISTCHECK_CONFIGURE_FLAGS = --disable-schemas-install --disable-update-mimedb
 
 run: $(PROGRAM)
 	(cd bin && LD_LIBRARY_PATH="../libtomboy/.libs${LD_LIBRARY_PATH+:$LD_LIBRARY_PATH}" mono --debug $(TOMBOY_DEV_MONO_OPTIONS) Tomboy.exe --debug --uninstalled $(TOMBOY_DEV_OPTIONS))

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ EXTRA_DIST = 			\
 	tomboy.spec.in		\
 	tomboy.spec			\
 	\
-	MAINTAINERS
+	tomboy.doap
 
 DISTCLEANFILES = 			\
 	\

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,20 +1,45 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+test -n "$srcdir" || srcdir=$(dirname "$0")
+test -n "$srcdir" || srcdir=.
 
-srcdir=`dirname $0`
-test -z "$srcdir" && srcdir=.
+olddir=$(pwd)
 
-PKG_NAME="tomboy"
+cd $srcdir
 
-(test -f $srcdir/configure.in) || {
-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
-    echo " top-level $PKG_NAME directory"
-    exit 1
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
+        exit 1
 }
 
-which gnome-autogen.sh || {
-    echo "You need to install gnome-common from your distro or GNOME git"
-    exit 1
-}
+# shellcheck disable=SC2016
+PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-REQUIRED_AUTOMAKE_VERSION=1.9 USE_GNOME2_MACROS=1 . gnome-autogen.sh
+if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
+        echo "*** If you wish to pass any to it, please specify them on the" >&2
+        echo "*** '$0' command line." >&2
+        echo "" >&2
+fi
+
+aclocal --install || exit 1
+# TODO: gnone-common migration page [1] says we should not run
+# glib-gettextize and intltoolize at the same time. We did that
+# in the old autogen.sh, so I'm leaving it as-is for now,
+# but this should be taken care of (GH issue #17).
+# [1] https://wiki.gnome.org/Projects/GnomeCommon/Migration
+glib-gettextize --force --copy || exit 1
+intltoolize --force --copy --automake || exit 1
+autoreconf --verbose --force --install || exit 1
+
+cd "$olddir"
+if [ "$NOCONFIGURE" = "" ]; then
+        $srcdir/configure "$@" || exit 1
+
+        if [ "$1" = "--help" ]; then exit 0 else
+                echo "Now type 'make' to compile $PKG_NAME" || exit 1
+        fi
+else
+        echo "Skipping configure process."
+fi
+

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,11 @@
 AC_INIT(tomboy, 1.15.6)
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR(Tomboy/Tomboy.cs)
 AM_INIT_AUTOMAKE([dist-xz foreign no-dist-gzip tar-ustar])
 AM_MAINTAINER_MODE
 
-GNOME_DOC_INIT([0.17.3])
+AX_REQUIRE_DEFINED([YELP_HELP_INIT])
+YELP_HELP_INIT
 
 AM_CONFIG_HEADER(config.h)
 

--- a/help/Makefile.am
+++ b/help/Makefile.am
@@ -1,10 +1,14 @@
 
-include $(top_srcdir)/gnome-doc-utils.make
-dist-hook: doc-dist-hook
+@YELP_HELP_RULES@
 
-DOC_ID = tomboy
+# TODO: it's unclear to me whether after migrating to Yelp
+# this is needed or not. Seems to work without it,
+# but needs to be checked. GH issue #18.
+#dist-hook: doc-dist-hook
+
+HELP_ID = tomboy
 DOC_INCLUDES = legal.xml
-DOC_FIGURES = \
+HELP_MEDIA = \
 	figures/add-notebook-search.png \
 	figures/add-to-notebook.png \
 	figures/delete-notebook.png \
@@ -25,7 +29,7 @@ DOC_FIGURES = \
 	figures/tomboy-preferences-synchronization.png \
 	figures/tomboy-tools.png
 
-DOC_PAGES = \
+HELP_FILES = \
 	addins-desktop-bugzilla.page \
 	addins-desktop-printing.page \
 	addins-formatting-fixed-width.page \
@@ -56,4 +60,4 @@ DOC_PAGES = \
 	sync.page \
 	whatsnew.page
 
-DOC_LINGUAS = ca cs de el en_GB es eu fr gl hu it lt lv oc pl pt_BR ro ru sl sv uk vi zh_CN
+HELP_LINGUAS = ca cs de el en_GB es eu fr gl hu it lt lv oc pl pt_BR ro ru sl sv uk vi zh_CN


### PR DESCRIPTION
According to https://wiki.gnome.org/Projects/GnomeCommon/Migration
we should migrate off using gnome-common macros in our build files.

@pwithnall if you are getting GitHub emails, I'd be grateful for a comment to make sure I've done it right as it took me quite some research to come up with that, due to the fact that most of these changes took place a while ago everywhere but in Tomboy.