### PR TITLE
Tomboy/Makefile.am add mkdir to .config target

### DIFF
--- a/Tomboy/Makefile.am
+++ b/Tomboy/Makefile.am
@@ -209,6 +209,7 @@ $(PANEL_WRAPPER): $(srcdir)/$(PANEL_WRAPPER).in Makefile
 	chmod +x $(PANEL_WRAPPER)
 
 $(TARGET).config: $(srcdir)/$(TARGET_NAME).config.in Makefile
+	mkdir -p `dirname $(TARGET)` && \
 	sed -e "s|\@pkglibdir\@|$(pkglibdir)|" \
 	    < $< > $@
 


### PR DESCRIPTION
This was failing quite reliably when building a Flatpak of Tomboy. Probably triggered depending on order / parallel make.